### PR TITLE
feat: added istio to k8s cluster deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,20 @@ setup:
 	./deployments/staging/setup
 	
 destroy:
+	# terraform workspace select setup
+	# terraform init ./deployments/staging/setup
+	# terraform destroy -force -var-file="input.tfvars.json" ./deployments/staging/setup
+
 	terraform workspace select deploy-cluster
 	terraform init ./deployments/staging/cluster
 	terraform destroy -force ./deployments/staging/cluster
 
+	rm input.tfvars.json
+
 destroy_setup:
-	terraform workspace select helm
-	terraform init ./helm
-	terraform destroy -force ./helm
+	terraform workspace select setup
+	terraform init ./deployments/staging/setup
+	terraform destroy -force -var-file="input.tfvars.json" ./deployments/staging/setup
 
 .PHONY: \
 	deploy \

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@ make deploy
 ```
 This will deploy a k8s cluster and download the `kube_config`
 
+It also generates a `input.tfvars.json` file that is used in step 2
+
 ### Step 2
 - Setup k8s cluster
 ```shell
 make setup
 ```
-Running this step must be ran directly after Step 1 as it has dependancies on `terraform output`
 
 ### Validations
 Run the following commands to validate everything has worked correctly
@@ -28,7 +29,7 @@ Run the following commands to validate everything has worked correctly
 ```shell
 kubectl get pods --all-namespaces
 ```
-See pod:
+See pod: 
 - tiller-deploy
 
 ```shell

--- a/deployments/staging/setup/main.tf
+++ b/deployments/staging/setup/main.tf
@@ -21,5 +21,5 @@ module "service_accounts" {
 
 module "cluster_helm" {
   source = "../../../modules/helm"
-  config = "${module.service_accounts.load_config_file}"
+  kubernetes_service_account_id = "${module.service_accounts.kubernetes_service_account_id}"
 }

--- a/modules/do-cluster/cluster.tf
+++ b/modules/do-cluster/cluster.tf
@@ -6,7 +6,7 @@ resource "digitalocean_kubernetes_cluster" "main" {
 
   node_pool {
     name       = "api-go"
-    size       = "s-1vcpu-2gb"
+    size       = "s-2vcpu-4gb"
     node_count = 3
   }
 

--- a/modules/do-cluster/database.tf
+++ b/modules/do-cluster/database.tf
@@ -12,7 +12,7 @@ resource "null_resource" "set_tf_vars" {
   depends_on = ["digitalocean_database_cluster.pg"]
 
   triggers = {
-    cluster_instance_id = "${digitalocean_database_cluster.pg.id}"
+    db_instance_id = "${digitalocean_database_cluster.pg.id}"
   }
 
   provisioner "local-exec" {

--- a/modules/helm/helm.tf
+++ b/modules/helm/helm.tf
@@ -5,6 +5,9 @@ provider "helm" {
 
 # This is hacky, for some reason helm doesn't install with the `provider`
 resource "null_resource" "install_helm" {
+  triggers = {
+    update = "${var.kubernetes_service_account_id}"
+  }
   provisioner "local-exec" {
     command = "helm init --service-account tiller"
   }

--- a/modules/helm/istio.tf
+++ b/modules/helm/istio.tf
@@ -7,24 +7,44 @@ output "istio" {
   value = "${data.helm_repository.istio-release}"
 }
 
-# resource "helm_release" "istio-release" {
-#   depends_on = ["null_resource.install_helm"]
-#   name       = "istio-release"
-#   repository = "${data.helm_repository.istio-release.metadata.0.name}"
-#   chart      = "istio"
-#   version    = "1.3.2"
+resource "helm_release" "istio-release" {
+  depends_on = ["null_resource.install_helm"]
 
-#   values = [
-#     "${file("charts.yaml")}"
-#   ]
+  name       = "istio-release"
+  namespace  = "istio-system"
+  repository = "${data.helm_repository.istio-release.metadata.0.name}"
+  chart      = "istio-init"
+  version    = "1.3.2"
 
-#   set {
-#     name  = "cluster.enabled"
-#     value = "true"
-#   }
+  set {
+    name  = "cluster.enabled"
+    value = "true"
+  }
 
-#   set {
-#     name  = "metrics.enabled"
-#     value = "true"
-#   }
-# }
+  set {
+    name  = "metrics.enabled"
+    value = "true"
+  }
+}
+
+resource "helm_release" "istio-default" {
+  depends_on = ["helm_release.istio-release"]
+
+  name       = "istio"
+  namespace  = "istio-system"
+  repository = "${data.helm_repository.istio-release.metadata.0.name}"
+  chart      = "istio"
+  version    = "1.3.2"
+
+  set {
+    name  = "cluster.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "metrics.enabled"
+    value = "true"
+  }
+}
+
+

--- a/modules/helm/variables.tf
+++ b/modules/helm/variables.tf
@@ -1,1 +1,1 @@
-variable "config" { default = false }
+variable "kubernetes_service_account_id" { default = false }

--- a/modules/service-accounts/outputs.tf
+++ b/modules/service-accounts/outputs.tf
@@ -1,3 +1,3 @@
-output "load_config_file" {
-  value = true
+output "kubernetes_service_account_id" {
+  value = "${kubernetes_service_account.tiller.id}"
 }


### PR DESCRIPTION
Added istio to k8s cluster. :tada: 

Setup plan now looks like this:

```
------------------------------------------------------------------------

An execution plan has been generated and is shown below.
Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # module.cluster_helm.helm_release.istio-default will be created
  + resource "helm_release" "istio-default" {
      + chart            = "istio"
      + disable_webhooks = false
      + force_update     = false
      + id               = (known after apply)
      + metadata         = (known after apply)
      + name             = "istio"
      + namespace        = "istio-system"
      + recreate_pods    = false
      + repository       = "istio-release"
      + reuse            = false
      + reuse_values     = false
      + status           = "DEPLOYED"
      + timeout          = 300
      + verify           = false
      + version          = "1.3.2"
      + wait             = true

      + set {
          + name  = "cluster.enabled"
          + value = "true"
        }
      + set {
          + name  = "metrics.enabled"
          + value = "true"
        }
    }

  # module.cluster_helm.helm_release.istio-release will be created
  + resource "helm_release" "istio-release" {
      + chart            = "istio-init"
      + disable_webhooks = false
      + force_update     = false
      + id               = (known after apply)
      + metadata         = (known after apply)
      + name             = "istio-release"
      + namespace        = "istio-system"
      + recreate_pods    = false
      + repository       = "istio-release"
      + reuse            = false
      + reuse_values     = false
      + status           = "DEPLOYED"
      + timeout          = 300
      + verify           = false
      + version          = "1.3.2"
      + wait             = true

      + set {
          + name  = "cluster.enabled"
          + value = "true"
        }
      + set {
          + name  = "metrics.enabled"
          + value = "true"
        }
    }

  # module.cluster_helm.null_resource.install_helm will be created
  + resource "null_resource" "install_helm" {
      + id       = (known after apply)
      + triggers = (known after apply)
    }

  # module.database_tables.postgresql_database.terraform_backend will be created
  + resource "postgresql_database" "terraform_backend" {
      + allow_connections = true
      + connection_limit  = -1
      + encoding          = (known after apply)
      + id                = (known after apply)
      + is_template       = (known after apply)
      + lc_collate        = "C"
      + lc_ctype          = (known after apply)
      + name              = "terraform_backend"
      + owner             = (known after apply)
      + tablespace_name   = (known after apply)
      + template          = (known after apply)
    }

  # module.service_accounts.kubernetes_cluster_role_binding.tiller will be created
  + resource "kubernetes_cluster_role_binding" "tiller" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "tiller"
          + resource_version = (known after apply)
          + self_link        = (known after apply)
          + uid              = (known after apply)
        }

      + role_ref {
          + api_group = "rbac.authorization.k8s.io"
          + kind      = "ClusterRole"
          + name      = "cluster-admin"
        }

      + subject {
          + api_group = "rbac.authorization.k8s.io"
          + kind      = "User"
          + name      = "admin"
          + namespace = "default"
        }
      + subject {
          + api_group = (known after apply)
          + kind      = "ServiceAccount"
          + name      = "tiller"
          + namespace = "kube-system"
        }
      + subject {
          + api_group = "rbac.authorization.k8s.io"
          + kind      = "Group"
          + name      = "system:masters"
          + namespace = "default"
        }
    }

  # module.service_accounts.kubernetes_namespace.go_apis will be created
  + resource "kubernetes_namespace" "go_apis" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "go-apis"
          + resource_version = (known after apply)
          + self_link        = (known after apply)
          + uid              = (known after apply)
        }
    }

  # module.service_accounts.kubernetes_namespace.istio will be created
  + resource "kubernetes_namespace" "istio" {
      + id = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "istio-system"
          + resource_version = (known after apply)
          + self_link        = (known after apply)
          + uid              = (known after apply)
        }
    }

  # module.service_accounts.kubernetes_service_account.tiller will be created
  + resource "kubernetes_service_account" "tiller" {
      + default_secret_name = (known after apply)
      + id                  = (known after apply)

      + metadata {
          + generation       = (known after apply)
          + name             = "tiller"
          + namespace        = "kube-system"
          + resource_version = (known after apply)
          + self_link        = (known after apply)
          + uid              = (known after apply)
        }
    }

Plan: 8 to add, 0 to change, 0 to destroy.

------------------------------------------------------------------------
```